### PR TITLE
Use patched version of xnos

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -20,6 +20,7 @@ jobs:
             python3 python3-yaml \
             xz-utils make gpg-agent
           python3 -m pip install -r ${{ env.DIR }}/requirements.txt
+          python3 -m pip install --force-reinstall git+https://github.com/tomduck/pandoc-xnos@284474574f51888be75603e7d1df667a0890504d#egg=pandoc-xnos
       - name: pandoc compile
         working-directory: ${{ env.DIR }}
         run: make all


### PR DESCRIPTION
There is a [long standing PR](https://github.com/tomduck/pandoc-xnos/pull/29) to update xnos to work with pandoc 3, but since its not released yet we need to add it manually.